### PR TITLE
Make it compatible with jquery.turbolinks

### DIFF
--- a/js/bootstrap-popover-x.js
+++ b/js/bootstrap-popover-x.js
@@ -126,7 +126,7 @@
     
     $.fn.popoverX.Constructor = PopoverX;
 
-    $(document).on('ready', function () {
+    $(document).ready(function () {
         $("[data-toggle='popover-x']").on('click', function (e) {
             var $this = $(this), href = $this.attr('href'),
                 $dialog = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))), //strip for ie7


### PR DESCRIPTION
When using rails [turbolinks](https://github.com/rails/turbolinks) page refreshes happen through ajax and don't trigger 'ready' events. However [jquery.turbolinks](https://github.com/kossnocorp/jquery.turbolinks) enables jquery to listen to 'page:load' events and trigger jQuery ready handlers.

`.ready()` is turbolinks-compatible and has been around since jQuery 1.0 and is practically synonymous with `on('ready')` which is not compatible with turbolinks.