### PR TITLE
Remove unused CSS class

### DIFF
--- a/css/bootstrap-popover-x.css
+++ b/css/bootstrap-popover-x.css
@@ -296,11 +296,6 @@
     border-right-color: #fbfbfb;
 }
 
-.popover-loading {
-    padding: 30px;
-    background: url('../img/loading.gif') center center;
-}
-
 /* hide modal backdrop */
 .popover-x-body .modal-backdrop {
     opacity: 1;


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- Removed a unused CSS class (prevents [Webpack](https://webpack.js.org/loaders/css-loader/) from compiling the stylesheet due to the invalid `url(...)` statement)

## Related Issues
\-